### PR TITLE
Feat: 몬스터 사망 동기화 헨들러 부분의 몬스터 아이디 가공 로직 추가.

### DIFF
--- a/src/classes/models/game.class.js
+++ b/src/classes/models/game.class.js
@@ -13,10 +13,10 @@ class Game {
     this.deleteAgreement = 0; //2가 되면 게임을 삭제합니다. 게임 엔드 페이로드가 오면 유저가 나가면서 하나를 올려줍니다. 모든 유저가 나가면 게임이 삭제됩니다. 생각해 보니까 삭제 시도 로직을 짜서 유저가 없을때만 삭제되게 하면 될지도.
     this.startTime = Date.now();
     this.playingTime = 0;
-    this.baseHp = 100,
-    this.towerCost = 100,
-    this.initialGold = 500,
-    this.monsterSpawnInterval = 1
+    this.baseHp = 100;
+    this.towerCost = 100;
+    this.initialGold = 500;
+    this.monsterSpawnInterval = 1;
   }
 
   //유저를 넣어둡니다. 유저에게 게임 아이디를 추가합니다.

--- a/src/handlers/monster/monsterDeathNotificationhandler.js
+++ b/src/handlers/monster/monsterDeathNotificationhandler.js
@@ -8,7 +8,13 @@ import { createResponse } from '../../utils/response/createResponse.js';
 
 const monsterDeathNotificationHandler = async ({ socket, sequence, payload }) => {
   try {
-    const { monsterId } = payload; //소켓으로 유저 찾아서 매칭.
+    let { monsterId } = payload; //소켓으로 유저 찾아서 매칭.
+
+
+    //어떤 타워가 죽였는지에 따라 번호가 다릅니다. 100~999는 1, 1000~1999는 2, 2000~2999는 3, 3000~3999는 4로 나옵니다.
+    const prefix = Math.floor(monsterId / 100000); 
+
+    monsterId = monsterId % 100000;
 
     const user = getUserBySocket(socket);
 


### PR DESCRIPTION
1.  몬스터 사망 동기화 헨들러 부분의 페이로드가 변경되어, 몬스터를 죽인 타워의 타입 + 몬스터 아이디 의 숫자를 줍니다.
이걸 분리하는 로직을 추가했습니다.